### PR TITLE
Go 1.11 is no longer the second generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # docker-appengine-go
 
-Docker Image for the [Google App Engine Go environment](https://cloud.google.com/appengine/docs/go/) second generation.
-Not support first generation Go 1.6, 1.8 and 1.9. first genation user use [mercari/docker-appengine-go](https://github.com/mercari/docker-appengine-go).
+Docker Image for the [Google App Engine Go environment](https://cloud.google.com/appengine/docs/go/) Go 1.11.
 
 ## Installation
 


### PR DESCRIPTION
Prior to Go 1.9, Deploy would not be possible, so I thought that no one would use it and deleted the text.